### PR TITLE
refactored common tests

### DIFF
--- a/include/dr/mhp/containers/distributed_vector.hpp
+++ b/include/dr/mhp/containers/distributed_vector.hpp
@@ -180,6 +180,7 @@ public:
   using iterator =
       lib::normal_distributed_iterator<dv_segments<distributed_vector>>;
   using reference = std::iter_reference_t<iterator>;
+  using allocator_type = Allocator;
 
   // Do not copy
   distributed_vector(const distributed_vector &) = delete;

--- a/include/dr/shp/distributed_vector.hpp
+++ b/include/dr/shp/distributed_vector.hpp
@@ -131,6 +131,7 @@ public:
   using iterator = distributed_vector_iterator<T, segment_type>;
   using const_iterator =
       distributed_vector_iterator<const T, const_segment_type>;
+  using allocator_type = Allocator;
 
   distributed_vector(std::size_t count = 0) {
     assert(shp::devices().size() > 0);

--- a/test/gtest/include/common-tests.hpp
+++ b/test/gtest/include/common-tests.hpp
@@ -93,6 +93,12 @@ std::vector<T> generate_random(std::size_t n, std::size_t bound = 25) {
   return v;
 }
 
+template <class DV> using LocalVec = std::vector<typename DV::value_type>;
+
+template <typename DV> inline auto default_policy() {
+  return default_policy_of_allocator<typename DV::allocator_type>();
+};
+
 #include "common/distributed_vector.hpp"
 #include "common/drop.hpp"
 #include "common/for_each.hpp"

--- a/test/gtest/include/common/distributed_vector.hpp
+++ b/test/gtest/include/common/distributed_vector.hpp
@@ -10,7 +10,7 @@ public:
 TYPED_TEST_SUITE_P(DistributedVector);
 
 TYPED_TEST_P(DistributedVector, Requirements) {
-  using DV = typename TypeParam::DV;
+  using DV = TypeParam;
   using DVI = typename DV::iterator;
   DV dv(10);
 
@@ -28,14 +28,11 @@ TYPED_TEST_P(DistributedVector, Requirements) {
 }
 
 TYPED_TEST_P(DistributedVector, Constructors) {
-  using DV = typename TypeParam::DV;
-  using DVA = typename TypeParam::DVA;
-  using V = typename TypeParam::V;
+  using DV = TypeParam;
+  using V = LocalVec<TypeParam>;
 
   DV a1(10);
-  DVA a2(10);
-  TypeParam::iota(a1, 10);
-  TypeParam::iota(a2, 10);
+  iota(a1, 10);
 
   DV a3(10, 2);
   if (comm_rank == 0) {

--- a/test/gtest/include/common/drop.hpp
+++ b/test/gtest/include/common/drop.hpp
@@ -10,18 +10,18 @@ public:
 TYPED_TEST_SUITE_P(Drop);
 
 TYPED_TEST_P(Drop, Basic) {
-  using DV = typename TypeParam::DV;
-  using V = typename TypeParam::V;
+  using DV = TypeParam;
+  using V = LocalVec<DV>;
 
   std::size_t n = 10;
 
   auto neg = [](auto &v) { v = -v; };
   DV dv_a(n);
-  TypeParam::iota(dv_a, 100);
+  iota(dv_a, 100);
   auto d = rng::views::drop(dv_a, 2);
   EXPECT_TRUE(check_segments(d));
   barrier();
-  xhp::for_each(TypeParam::policy(), d, neg);
+  xhp::for_each(default_policy<DV>(), d, neg);
 
   if (comm_rank == 0) {
     V a(n), a_in(n);

--- a/test/gtest/include/common/for_each.hpp
+++ b/test/gtest/include/common/for_each.hpp
@@ -10,15 +10,15 @@ public:
 TYPED_TEST_SUITE_P(ForEach);
 
 TYPED_TEST_P(ForEach, Basic) {
-  using DV = typename TypeParam::DV;
-  using V = typename TypeParam::V;
+  using DV = TypeParam;
+  using V = LocalVec<DV>;
 
   std::size_t n = 10;
 
   auto neg = [](auto &v) { v = -v; };
   DV dv_a(n);
-  TypeParam::iota(dv_a, 100);
-  xhp::for_each(TypeParam::policy(), dv_a, neg);
+  iota(dv_a, 100);
+  xhp::for_each(default_policy<DV>(), dv_a, neg);
 
   if (comm_rank == 0) {
     V a(n), a_in(n);

--- a/test/gtest/include/common/subrange.hpp
+++ b/test/gtest/include/common/subrange.hpp
@@ -10,18 +10,18 @@ public:
 TYPED_TEST_SUITE_P(Subrange);
 
 TYPED_TEST_P(Subrange, Basic) {
-  using DV = typename TypeParam::DV;
-  using V = typename TypeParam::V;
+  using DV = TypeParam;
+  using V = LocalVec<DV>;
 
   std::size_t n = 10;
 
   auto neg = [](auto &v) { v = -v; };
   DV dv_a(n);
-  TypeParam::iota(dv_a, 100);
+  iota(dv_a, 100);
   auto sr = rng::subrange(dv_a.begin() + 1, dv_a.end() - 1);
   EXPECT_TRUE(check_segments(sr));
   barrier();
-  xhp::for_each(TypeParam::policy(), sr, neg);
+  xhp::for_each(default_policy<DV>(), sr, neg);
 
   if (comm_rank == 0) {
     V a(n), a_in(n);

--- a/test/gtest/include/common/take.hpp
+++ b/test/gtest/include/common/take.hpp
@@ -10,18 +10,18 @@ public:
 TYPED_TEST_SUITE_P(Take);
 
 TYPED_TEST_P(Take, DISABLED_Basic) {
-  using DV = typename TypeParam::DV;
-  using V = typename TypeParam::V;
+  using DV = TypeParam;
+  using V = LocalVec<DV>;
 
   std::size_t n = 10;
 
   auto neg = [](auto &v) { v = -v; };
   DV dv_a(n);
-  TypeParam::iota(dv_a, 100);
+  iota(dv_a, 100);
   auto t = rng::views::take(dv_a, 6);
   EXPECT_TRUE(check_segments(t));
   barrier();
-  xhp::for_each(TypeParam::policy(), t, neg);
+  xhp::for_each(default_policy<DV>(), t, neg);
 
   if (comm_rank == 0) {
     V a(n), a_in(n);

--- a/test/gtest/include/common/transform_view.hpp
+++ b/test/gtest/include/common/transform_view.hpp
@@ -10,14 +10,14 @@ public:
 TYPED_TEST_SUITE_P(TransformView);
 
 TYPED_TEST_P(TransformView, Basic) {
-  using DV = typename TypeParam::DV;
-  using V = typename TypeParam::V;
+  using DV = TypeParam;
+  using V = LocalVec<DV>;
 
   std::size_t n = 10;
 
   auto neg = [](auto v) { return -v; };
   DV dv_a(n);
-  TypeParam::iota(dv_a, 100);
+  iota(dv_a, 100);
   auto dv_t = lib::views::transform(dv_a, neg);
   EXPECT_TRUE(check_segments(dv_t));
   barrier();

--- a/test/gtest/include/common/zip.hpp
+++ b/test/gtest/include/common/zip.hpp
@@ -10,15 +10,15 @@ public:
 TYPED_TEST_SUITE_P(Zip);
 
 TYPED_TEST_P(Zip, Basic) {
-  using DV = typename TypeParam::DV;
-  using V = typename TypeParam::V;
+  using DV = TypeParam;
+  using V = LocalVec<DV>;
 
   std::size_t n = 10;
 
   DV dv_a(n), dv_b(n), dv_c(n);
-  TypeParam::iota(dv_a, 100);
-  TypeParam::iota(dv_b, 200);
-  TypeParam::iota(dv_c, 300);
+  iota(dv_a, 100);
+  iota(dv_b, 200);
+  iota(dv_c, 300);
 
   // DISABLE 2 zip
   // auto d_z2 = zhp::zip(dv_a, dv_b);

--- a/test/gtest/mhp/mhp-tests.cpp
+++ b/test/gtest/mhp/mhp-tests.cpp
@@ -5,32 +5,12 @@
 #include "mhp-tests.hpp"
 
 // Instantiate MHP-specific configurations for common tests
-template <typename T> struct CommonTestConfigBase {
-  using DV = mhp::distributed_vector<T>;
-  using DVA = mhp::distributed_vector<T, std::allocator<T>>;
-  using V = std::vector<T>;
-
-  static auto iota(auto &&r, auto val) { return mhp::iota(r, val); }
-};
-template <typename T>
-struct CommonTestConfigCPU : public CommonTestConfigBase<T> {
-  using DV = mhp::distributed_vector<T>;
-  using DVA = mhp::distributed_vector<T, std::allocator<T>>;
-  static auto policy() { return std::execution::par_unseq; }
-};
-#ifdef SYCL_LANGUAGE_VERSION
-template <typename T>
-struct CommonTestConfigSYCL : public CommonTestConfigBase<T> {
-  using DV = mhp::distributed_vector<T, mhp::sycl_shared_allocator<T>>;
-  using DVA = DV;
-  static auto policy() { return mhp::device_policy(); }
-};
-#endif
 using Common_Types = ::testing::Types<
 #ifdef SYCL_LANGUAGE_VERSION
-    CommonTestConfigSYCL<int>, CommonTestConfigSYCL<float>,
+    mhp::distributed_vector<int>, mhp::distributed_vector<float>,
 #endif
-    CommonTestConfigCPU<int>, CommonTestConfigCPU<float>>;
+    mhp::distributed_vector<int, mhp::sycl_shared_allocator<int>>,
+    mhp::distributed_vector<float, mhp::sycl_shared_allocator<float>>>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(MHP, DistributedVector, Common_Types);
 INSTANTIATE_TYPED_TEST_SUITE_P(MHP, Drop, Common_Types);

--- a/test/gtest/mhp/mhp-tests.hpp
+++ b/test/gtest/mhp/mhp-tests.hpp
@@ -16,6 +16,19 @@ namespace xhp = mhp;
 inline void barrier() { mhp::barrier(); }
 inline void fence() { mhp::fence(); }
 
+template <typename T>
+  requires(
+      std::is_same_v<T, mhp::sycl_shared_allocator<typename T::value_type>>)
+inline auto default_policy_of_allocator() {
+  return mhp::device_policy();
+}
+
+template <typename T>
+  requires(std::is_same_v<T, std::allocator<typename T::value_type>>)
+inline auto default_policy_of_allocator() {
+  return std::execution::par_unseq;
+}
+
 #include "common-tests.hpp"
 
 // MHP specific tests

--- a/test/gtest/shp/shp-tests.cpp
+++ b/test/gtest/shp/shp-tests.cpp
@@ -5,20 +5,11 @@
 #include "shp-tests.hpp"
 
 // Instantiate SHP-specific configurations for common tests
-template <typename T> struct CommonTestConfig {
-  using DV = shp::distributed_vector<T>;
-  using DVA = shp::distributed_vector<T, shp::device_allocator<int>>;
-  using V = std::vector<T>;
-  static auto policy() { return shp::par_unseq; }
-
-  // Need shp::iota
-  // Why doesn't rng::iota work?
-  static auto iota(auto &&r, auto val) {
-    return std::iota(r.begin(), r.end(), val);
-  }
-};
-using Common_Types =
-    ::testing::Types<CommonTestConfig<int>, CommonTestConfig<float>>;
+using Common_Types = ::testing::Types<
+    shp::distributed_vector<int, shp::device_allocator<int>>,
+    shp::distributed_vector<float, shp::device_allocator<float>>,
+    shp::distributed_vector<int, shp::shared_allocator<int>>,
+    shp::distributed_vector<float, shp::shared_allocator<float>>>;
 
 INSTANTIATE_TYPED_TEST_SUITE_P(MHP, DistributedVector, Common_Types);
 INSTANTIATE_TYPED_TEST_SUITE_P(SHP, Drop, Common_Types);

--- a/test/gtest/shp/shp-tests.hpp
+++ b/test/gtest/shp/shp-tests.hpp
@@ -16,6 +16,8 @@ namespace xhp = shp;
 inline void barrier() {}
 inline void fence() {}
 
+// Need shp::iota
+// Why doesn't rng::iota work?
 auto iota(auto &&r, auto val) { return std::iota(r.begin(), r.end(), val); }
 
 template <typename T> auto default_policy_of_allocator() {

--- a/test/gtest/shp/shp-tests.hpp
+++ b/test/gtest/shp/shp-tests.hpp
@@ -16,4 +16,10 @@ namespace xhp = shp;
 inline void barrier() {}
 inline void fence() {}
 
+auto iota(auto &&r, auto val) { return std::iota(r.begin(), r.end(), val); }
+
+template <typename T> auto default_policy_of_allocator() {
+  return shp::par_unseq;
+};
+
 #include "common-tests.hpp"


### PR DESCRIPTION
I propose some changes.
- iota moved to be standalone function is shp-tests, IMO shp-tests.hpp and mhp-tests.hpp are better places to keep xhp specific specializations than type customizing the test
- get rid of DV/DVA typedefs - sometimes they are same and thus redundant, sometimes they were different and thus should be different cases, now they test separately when different
- created default_policy helper in tests, as policy is deducible from allocator type. This allowed to pass just simple vector types to INSTANTIATE_TYPED_TESTS_P instead of configs